### PR TITLE
Plone 4 jquery fix

### DIFF
--- a/Solgema/ContextualContentMenu/viewlets/contentactions.pt
+++ b/Solgema/ContextualContentMenu/viewlets/contentactions.pt
@@ -7,7 +7,7 @@
     <li>
       <dl id="menuItemActions" class="actionMenu">
         <dt tal:attributes="class string:actionMenuHeader label-actions">
-          <a tal:attributes="herf context/absolute_url">
+          <a tal:attributes="href context/absolute_url">
             <span i18n:domain="zope" i18n:translate="">Object</span>
             <span class="arrowDownAlternative">&#9660;</span>
           </a>
@@ -28,7 +28,7 @@
                     <span tal:content="action/title" i18n:translate="">
                         Action name
                     </span>
-                </a>            
+                </a>
 
             </li>
         </ul>

--- a/docs/HISTORY.rst
+++ b/docs/HISTORY.rst
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+0.3 (unreleased)
+----------------
+
+- fix markup to prevent plone4.csrffixes from running into a TypeError
+  (this fixes #3) [fRiSi]
+
+
 0.2
 ---
 


### PR DESCRIPTION
This is branch for Plone4 with the markup fix. 

We use jquery below 1.5 and this version cant send the csfr header on $.get and fails. 
As protect.js already adds the CSRF Header (in newer plone 4.3.19), use this branch for a fix.
And update to plone5! :)